### PR TITLE
Test mac os (#53)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,20 @@ on:
     branches: [ master ]
 
 jobs:
-  shellcheck:
-    name: Test
+  linuxTest:
+    name: Test on Linux
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 
     - name: Run testing script
+      run: ./testing.sh
+
+  macOsTest:
+    name: Test on macOS
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Run testing script on macOS
       run: ./testing.sh

--- a/testing.sh
+++ b/testing.sh
@@ -10,6 +10,25 @@ log_error_file=./error.log
 test_data_src=./test/pool
 test_pool_data_path=./testing_data
 
+## Color Constants
+
+# Reset
+Color_Off='\033[0m' # Text Reset
+
+# Regular Colors
+Red='\033[0;31m'    # Red
+Green='\033[0;32m'  # Green
+Cyan='\033[0;36m'   # Cyan
+
+## Functions
+
+# print a given text entirely in a given color
+function color_echo () {
+  color=$1
+  text=$2
+  echo -e "${color}${text}${Color_Off}"
+}
+
 function prepare() {
   # cleanup
   rm -f $log_std_file
@@ -24,7 +43,7 @@ function prepare() {
 function assertions() {
   # check error log is empty
   if grep -q '[^[:space:]]' $log_error_file; then
-    echo "error log is not empty!"
+    color_echo "$Red" "error log is not empty!"
     cat $log_error_file
     exit 1
   fi
@@ -44,21 +63,30 @@ function assert_matching_file_not_copied() {
   fi
 }
 
+color_echo "$Cyan" "Running tests..."
+
+color_echo "$Cyan" "Running tests with default options..."
 prepare
 ./zfs-inplace-rebalancing.sh $test_pool_data_path >> $log_std_file 2>> $log_error_file
 cat $log_std_file
 assertions
+color_echo "$Green" "Tests passed!"
 
+color_echo "$Cyan" "Running tests with checksum true and 1 pass..."
 prepare
 ./zfs-inplace-rebalancing.sh --checksum true --passes 1 $test_pool_data_path >> $log_std_file 2>> $log_error_file
 cat $log_std_file
 assertions
+color_echo "$Green" "Tests passed!"
 
+color_echo "$Cyan" "Running tests with checksum false..."
 prepare
 ./zfs-inplace-rebalancing.sh --checksum false $test_pool_data_path >> $log_std_file 2>> $log_error_file
 cat $log_std_file
 assertions
+color_echo "$Green" "Tests passed!"
 
+color_echo "$Cyan" "Running tests with skip-hardlinks false..."
 prepare
 ln "$test_pool_data_path/projects/[2020] some project/mp4.txt" "$test_pool_data_path/projects/[2020] some project/mp4.txt.link"
 ./zfs-inplace-rebalancing.sh --skip-hardlinks false $test_pool_data_path >> $log_std_file 2>> $log_error_file
@@ -67,7 +95,9 @@ cat $log_std_file
 assert_matching_file_copied "mp4.txt"
 assert_matching_file_copied "mp4.txt.link"
 assertions
+color_echo "$Green" "Tests passed!"
 
+color_echo "$Cyan" "Running tests with skip-hardlinks true..."
 prepare
 ln "$test_pool_data_path/projects/[2020] some project/mp4.txt" "$test_pool_data_path/projects/[2020] some project/mp4.txt.link"
 ./zfs-inplace-rebalancing.sh --skip-hardlinks true $test_pool_data_path >> $log_std_file 2>> $log_error_file
@@ -76,3 +106,6 @@ cat $log_std_file
 assert_matching_file_not_copied "mp4.txt.link"
 assert_matching_file_not_copied "mp4.txt"
 assertions
+color_echo "$Green" "Tests passed!"
+
+color_echo "$Green" "All tests passed!"


### PR DESCRIPTION
* add: test on MacOS

Add test for MacOS in Github action

Maybe see this to add test for FreeBSD :
https://github.com/marketplace/actions/freebsd-vm

* add: log to test

adding log to the test for better understanding

* fix: shellcheck

remove the yellow color that is unused in the test

* fix: fail on lower-casting

the `"${variable,,}"` seam to not work on macOS so y remove it for the `skip_hardlink_flag` because it's always lowercase

* fix: macOS

remove all the lower-case casting

* fix(perf): going to `stat` remove `lsattr` macOS

The command `lsattr` is not supported on macOS so I have remove it switch to `stat` instead of `ls` for better performance and no subshell use of parameter expansion with  `%` in place of `awk` for performance and no subshell

* fix: forgot to remove variable